### PR TITLE
Ignore install folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,8 @@ _deps
 # Recommended build folder for out-of-source builds
 build
 
+# Ignore the install directory
+install
+
 # End of https://www.toptal.com/developers/gitignore/api/c++,cmake,c
 


### PR DESCRIPTION
In case one would like to install the project in a dedicated "install" folder within the project root. This commit ignores the folder in git.